### PR TITLE
ID-1832: Support additional parameters for `reverse ip`, `load hash` and `reverse email` actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,14 +167,20 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
 **tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string | 
 **create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
+**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string | 
+**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string | 
+**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string | 
 **expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
 action\_result\.parameter\.create\_date | string | 
+action\_result\.parameter\.create\_date\_within | string | 
 action\_result\.parameter\.data\_updated\_after | string | 
 action\_result\.parameter\.expiration\_date | string | 
+action\_result\.parameter\.first\_seen\_since | string | 
+action\_result\.parameter\.first\_seen\_within | string | 
 action\_result\.parameter\.ip | string |  `ip` 
 action\_result\.parameter\.status | string | 
 action\_result\.parameter\.tld | string | 
@@ -200,14 +206,20 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
 **tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string | 
 **create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
+**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string | 
+**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string | 
+**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string | 
 **expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
 action\_result\.parameter\.create\_date | string | 
+action\_result\.parameter\.create\_date\_within | string | 
 action\_result\.parameter\.data\_updated\_after | string | 
 action\_result\.parameter\.expiration\_date | string | 
+action\_result\.parameter\.first\_seen\_since | string | 
+action\_result\.parameter\.first\_seen\_within | string | 
 action\_result\.parameter\.hash | string | 
 action\_result\.parameter\.status | string | 
 action\_result\.parameter\.tld | string | 
@@ -233,15 +245,21 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
 **tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string | 
 **create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
+**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string | 
+**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string | 
+**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string | 
 **expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
 action\_result\.parameter\.create\_date | string | 
+action\_result\.parameter\.create\_date\_within | string | 
 action\_result\.parameter\.data\_updated\_after | string | 
 action\_result\.parameter\.email | string |  `email` 
 action\_result\.parameter\.expiration\_date | string | 
+action\_result\.parameter\.first\_seen\_since | string | 
+action\_result\.parameter\.first\_seen\_within | string | 
 action\_result\.parameter\.status | string | 
 action\_result\.parameter\.tld | string | 
 action\_result\.data\.\*\.domain | string |  `domain` 

--- a/domaintools_iris.json
+++ b/domaintools_iris.json
@@ -490,10 +490,28 @@
                     "data_type": "string",
                     "order": 4
                 },
+                "create_date_within": {
+                    "description": "Only include domains with a whois create date within the specified number of days (e.g. specifying '1' would indicate within the past day)",
+                    "data_type": "string",
+                    "order": 5,
+                    "name": "create_date_within"
+                },
+                "first_seen_within": {
+                    "description": "Only include domains with a current lifecycle first observed within the specified number of seconds (e.g. specifying '86400' would indicate within the past day)",
+                    "data_type": "string",
+                    "order": 6,
+                    "name": "first_seen_within"
+                },
+                "first_seen_since": {
+                    "description": "Only include domains with a current lifecycle first observed since a specified datetime. (Example: 2023-04-10T00:00:00+00:00)",
+                    "data_type": "string",
+                    "order": 7,
+                    "name": "first_seen_since"
+                },
                 "expiration_date": {
                     "description": "Only include domains expiring on a specific date, in YYYY-MM-DD format or relative options ( 'today', 'yesterday' )",
                     "data_type": "string",
-                    "order": 5
+                    "order": 8
                 }
             },
             "render": {
@@ -508,11 +526,23 @@
                     "data_type": "string"
                 },
                 {
+                    "data_path": "action_result.parameter.create_date_within",
+                    "data_type": "string"
+                },
+                {
                     "data_path": "action_result.parameter.data_updated_after",
                     "data_type": "string"
                 },
                 {
                     "data_path": "action_result.parameter.expiration_date",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.first_seen_within",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.first_seen_since",
                     "data_type": "string"
                 },
                 {
@@ -619,10 +649,28 @@
                     "data_type": "string",
                     "order": 4
                 },
+                "create_date_within": {
+                    "description": "Only include domains with a whois create date within the specified number of days (e.g. specifying '1' would indicate within the past day)",
+                    "data_type": "string",
+                    "order": 5,
+                    "name": "create_date_within"
+                },
+                "first_seen_within": {
+                    "description": "Only include domains with a current lifecycle first observed within the specified number of seconds (e.g. specifying '86400' would indicate within the past day)",
+                    "data_type": "string",
+                    "order": 6,
+                    "name": "first_seen_within"
+                },
+                "first_seen_since": {
+                    "description": "Only include domains with a current lifecycle first observed since a specified datetime. (Example: 2023-04-10T00:00:00+00:00)",
+                    "data_type": "string",
+                    "order": 7,
+                    "name": "first_seen_since"
+                },
                 "expiration_date": {
                     "description": "Only include domains expiring on a specific date, in YYYY-MM-DD format or relative options ( 'today', 'yesterday' )",
                     "data_type": "string",
-                    "order": 5
+                    "order": 8
                 }
             },
             "render": {
@@ -637,11 +685,23 @@
                     "data_type": "string"
                 },
                 {
+                    "data_path": "action_result.parameter.create_date_within",
+                    "data_type": "string"
+                },
+                {
                     "data_path": "action_result.parameter.data_updated_after",
                     "data_type": "string"
                 },
                 {
                     "data_path": "action_result.parameter.expiration_date",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.first_seen_within",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.first_seen_since",
                     "data_type": "string"
                 },
                 {
@@ -747,10 +807,28 @@
                     "data_type": "string",
                     "order": 4
                 },
+                "create_date_within": {
+                    "description": "Only include domains with a whois create date within the specified number of days (e.g. specifying '1' would indicate within the past day)",
+                    "data_type": "string",
+                    "order": 5,
+                    "name": "create_date_within"
+                },
+                "first_seen_within": {
+                    "description": "Only include domains with a current lifecycle first observed within the specified number of seconds (e.g. specifying '86400' would indicate within the past day)",
+                    "data_type": "string",
+                    "order": 6,
+                    "name": "first_seen_within"
+                },
+                "first_seen_since": {
+                    "description": "Only include domains with a current lifecycle first observed since a specified datetime. (Example: 2023-04-10T00:00:00+00:00)",
+                    "data_type": "string",
+                    "order": 7,
+                    "name": "first_seen_since"
+                },
                 "expiration_date": {
                     "description": "Only include domains expiring on a specific date, in YYYY-MM-DD format or relative options ( 'today', 'yesterday' )",
                     "data_type": "string",
-                    "order": 5
+                    "order": 8
                 }
             },
             "render": {
@@ -762,6 +840,10 @@
             "output": [
                 {
                     "data_path": "action_result.parameter.create_date",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.create_date_within",
                     "data_type": "string"
                 },
                 {
@@ -779,6 +861,14 @@
                 },
                 {
                     "data_path": "action_result.parameter.expiration_date",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.first_seen_within",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.first_seen_since",
                     "data_type": "string"
                 },
                 {


### PR DESCRIPTION
Changes:
1. Added support for `create_date_within`, `first_seen_within` and `first_seen_since` parameters for `reverse ip`, `load hash` and `reverse email` actions.

Demo:
https://www.loom.com/share/f64bd010089648f1a1bec20b361c362a