### PR TITLE
ID-1822-Splunk SOAR: remove unsupported search hash fields and update help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 [pivot action](#action-pivot-action) - Find domains connected by any supported Iris Investigate search parameter  
 [reverse domain](#action-reverse-domain) - Extract IPs from a single domain response for further pivoting  
 [reverse ip](#action-reverse-ip) - Find domains with web hosting IP, NS IP or MX IP  
-[load hash](#action-load-hash) - Load or monitor Iris Investigate search results by Iris Investigate export hash  
+[load search hash](#action-load-search-hash) - Load or monitor Iris Investigate search results by Iris Investigate export hash  
 [reverse email](#action-reverse-email) - Find domains with email in Whois, DNS SOA or SSL certificate  
 [lookup domain](#action-lookup-domain) - Get all Iris Investigate data for a domain using the Iris Investigate API endpoint \(required\)  
 [enrich domain](#action-enrich-domain) - Get all Iris Investigate data for a domain except counts using the high volume Iris Enrich API endpoint \(if provisioned\)  
@@ -210,7 +210,7 @@ action\_result\.summary | string |
 summary\.total\_objects | numeric | 
 summary\.total\_objects\_successful | numeric |   
 
-## action: 'load hash'
+## action: 'load search hash'
 Load or monitor Iris Investigate search results by Iris Investigate export hash
 
 Type: **investigate**  
@@ -219,28 +219,12 @@ Read only: **True**
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**hash** |  required  | Iris Investigate search hash to load | string | 
-**status** |  optional  | Return domains of this registration type | string | 
-**data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
-**tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string | 
-**create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
-**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string | 
-**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string | 
-**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string | 
-**expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
+**Iris\_Ivestigate_search\_hash** |  required  | Iris Investigate search hash to load | string | 
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.create\_date | string | 
-action\_result\.parameter\.create\_date\_within | string | 
-action\_result\.parameter\.data\_updated\_after | string | 
-action\_result\.parameter\.expiration\_date | string | 
-action\_result\.parameter\.first\_seen\_since | string | 
-action\_result\.parameter\.first\_seen\_within | string | 
-action\_result\.parameter\.hash | string | 
-action\_result\.parameter\.status | string | 
-action\_result\.parameter\.tld | string | 
+action\_result\.parameter\.Iris\_Investigate\_search\_hash | string | 
 action\_result\.data\.\*\.domain | string |  `domain` 
 action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric | 
 action\_result\.data\.\*\.first\_seen\.count | numeric 

--- a/README.md
+++ b/README.md
@@ -219,12 +219,12 @@ Read only: **True**
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**Iris\_Ivestigate_search\_hash** |  required  | Iris Investigate search hash to load | string | 
+**search\_hash** |  required  | Iris Investigate search hash to load | string | 
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.Iris\_Investigate\_search\_hash | string | 
+action\_result\.parameter\.search\_hash | string | 
 action\_result\.data\.\*\.domain | string |  `domain` 
 action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric | 
 action\_result\.data\.\*\.first\_seen\.count | numeric 

--- a/domaintools_iris.json
+++ b/domaintools_iris.json
@@ -659,66 +659,17 @@
             "versions": "EQ(*)"
         },
         {
-            "action": "load hash",
+            "action": "load search hash",
             "description": "Load or monitor Iris Investigate search results by Iris Investigate export hash",
             "type": "investigate",
             "identifier": "load_hash",
             "read_only": true,
             "parameters": {
-                "hash": {
-                    "description": "Iris Investigate search hash to load",
+                "Iris_Investigate_search_hash": {
+                    "description": "Current Search Export string (Advanced -> Import/Export Search) from Iris Investigate in this field to import up to 5000 domains",
                     "data_type": "string",
                     "required": true,
                     "order": 0
-                },
-                "status": {
-                    "description": "Return domains of this registration type",
-                    "data_type": "string",
-                    "value_list": [
-                        "Any",
-                        "Active",
-                        "Inactive"
-                    ],
-                    "default": "Any",
-                    "order": 1
-                },
-                "data_updated_after": {
-                    "description": "Iris Investigate records that were updated on or after midnight on this date, in YYYY-MM-DD format or relative options ( 'today', 'yesterday' )",
-                    "data_type": "string",
-                    "order": 2
-                },
-                "tld": {
-                    "description": "Limit results to only include domains in a specific top-level domain (i.e. \u201ctld=com\u201d or \u201ctld=ru\u201d)",
-                    "data_type": "string",
-                    "order": 3
-                },
-                "create_date": {
-                    "description": "Only include domains created on a specific date, in YYYY-MM-DD format or relative options ( 'today', 'yesterday' )",
-                    "data_type": "string",
-                    "order": 4
-                },
-                "create_date_within": {
-                    "description": "Only include domains with a whois create date within the specified number of days (e.g. specifying '1' would indicate within the past day)",
-                    "data_type": "string",
-                    "order": 5,
-                    "name": "create_date_within"
-                },
-                "first_seen_within": {
-                    "description": "Only include domains with a current lifecycle first observed within the specified number of seconds (e.g. specifying '86400' would indicate within the past day)",
-                    "data_type": "string",
-                    "order": 6,
-                    "name": "first_seen_within"
-                },
-                "first_seen_since": {
-                    "description": "Only include domains with a current lifecycle first observed since a specified datetime. (Example: 2023-04-10T00:00:00+00:00)",
-                    "data_type": "string",
-                    "order": 7,
-                    "name": "first_seen_since"
-                },
-                "expiration_date": {
-                    "description": "Only include domains expiring on a specific date, in YYYY-MM-DD format or relative options ( 'today', 'yesterday' )",
-                    "data_type": "string",
-                    "order": 8
                 }
             },
             "render": {
@@ -729,39 +680,7 @@
             },
             "output": [
                 {
-                    "data_path": "action_result.parameter.create_date",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.parameter.create_date_within",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.parameter.data_updated_after",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.parameter.expiration_date",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.parameter.first_seen_within",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.parameter.first_seen_since",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.parameter.hash",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.parameter.status",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.parameter.tld",
+                    "data_path": "action_result.parameter.Iris_Investigate_search_hash",
                     "data_type": "string"
                 },
                 {

--- a/domaintools_iris.json
+++ b/domaintools_iris.json
@@ -25,6 +25,9 @@
         },
         {
             "name": "Jairdan Babac"
+        },
+        {
+            "name": "Brian Luza"
         }
     ],
     "configuration": {
@@ -662,10 +665,10 @@
             "action": "load search hash",
             "description": "Load or monitor Iris Investigate search results by Iris Investigate export hash",
             "type": "investigate",
-            "identifier": "load_hash",
+            "identifier": "load_search_hash",
             "read_only": true,
             "parameters": {
-                "Iris_Investigate_search_hash": {
+                "search_hash": {
                     "description": "Current Search Export string (Advanced -> Import/Export Search) from Iris Investigate in this field to import up to 5000 domains",
                     "data_type": "string",
                     "required": true,
@@ -680,7 +683,7 @@
             },
             "output": [
                 {
-                    "data_path": "action_result.parameter.Iris_Investigate_search_hash",
+                    "data_path": "action_result.parameter.search_hash",
                     "data_type": "string"
                 },
                 {

--- a/domaintools_iris_connector.py
+++ b/domaintools_iris_connector.py
@@ -457,10 +457,11 @@ class DomainToolsConnector(BaseConnector):
         return self._pivot_action(param)
 
     def _load_hash(self, param):
+        param_hash = param.get("Iris_Investigate_search_hash") or ""
         data = {
             "pivot_type": "search_hash",
-            "query_value": param["hash"],
-            "hash": param["hash"],
+            "query_value": param_hash,
+            "hash": param_hash,
         }
         param.update(data)
         return self._pivot_action(param)

--- a/domaintools_iris_connector.py
+++ b/domaintools_iris_connector.py
@@ -31,7 +31,7 @@ class DomainToolsConnector(BaseConnector):
     ACTION_ID_REVERSE_IP = "reverse_lookup_ip"
     ACTION_ID_REVERSE_EMAIL = "reverse_whois_email"
     ACTION_ID_REVERSE_DOMAIN = "reverse_lookup_domain"
-    ACTION_ID_LOAD_HASH = "load_hash"
+    ACTION_ID_LOAD_SEARCH_HASH = "load_search_hash"
 
     def __init__(self):
         # Call the BaseConnectors init first
@@ -313,8 +313,8 @@ class DomainToolsConnector(BaseConnector):
             ret_val = self._reverse_whois_email(param)
         elif action_id == self.ACTION_ID_REVERSE_DOMAIN:
             ret_val = self._reverse_lookup_domain(param)
-        elif action_id == self.ACTION_ID_LOAD_HASH:
-            ret_val = self._load_hash(param)
+        elif action_id == self.ACTION_ID_LOAD_SEARCH_HASH:
+            ret_val = self._load_search_hash(param)
 
         return ret_val
 
@@ -456,8 +456,8 @@ class DomainToolsConnector(BaseConnector):
         param.update(updates)
         return self._pivot_action(param)
 
-    def _load_hash(self, param):
-        param_hash = param.get("Iris_Investigate_search_hash") or ""
+    def _load_search_hash(self, param):
+        param_hash = param.get("search_hash") or ""
         data = {
             "pivot_type": "search_hash",
             "query_value": param_hash,


### PR DESCRIPTION
Loom Video: https://www.loom.com/share/3a373cb2f87c43fc8739cfcca88f623f

- Change `load hash` to `load search hash`
- Remove other fields and change `hash` to `search hash`
- Update field tooltip description

Overall, the change is focus on 'load hash' action and more on a UI change. Did some changes in the `domaintools_iris_connector.py` file to align the new param name.