### PR TITLE
add the missing text in load search hash description

### DIFF
--- a/domaintools_iris.json
+++ b/domaintools_iris.json
@@ -669,7 +669,7 @@
             "read_only": true,
             "parameters": {
                 "search_hash": {
-                    "description": "Current Search Export string (Advanced -> Import/Export Search) from Iris Investigate in this field to import up to 5000 domains",
+                    "description": "Paste the \"Current Search Export\" string (Advanced -> Import/Export Search) from Iris Investigate in this field to import up to 5000 domains",
                     "data_type": "string",
                     "required": true,
                     "order": 0


### PR DESCRIPTION

- add the missing "Paste the" word in load search hash description

![image](https://github.com/DomainTools/domaintoolsiris/assets/133698148/2102bcef-eea9-43f2-a0d4-5e502fa81c69)
