### PR TITLE
ID-1858: Fix issue in sorting risk score in table template.

### DIFF
--- a/domaintools_iris.json
+++ b/domaintools_iris.json
@@ -346,7 +346,11 @@
                 },
                 {
                     "data_path": "action_result.data.*.domain_risk.risk_score",
-                    "data_type": "numeric",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.domain_risk.risk_score_string",
+                    "data_type": "string",
                     "column_order": 1,
                     "column_name": "Risk Score"
                 },
@@ -459,7 +463,11 @@
                 },
                 {
                     "data_path": "action_result.summary.ip_list.*.count",
-                    "data_type": "numeric",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.summary.ip_list.*.count_string",
+                    "data_type": "string",
                     "column_order": 2,
                     "column_name": "Connected Domain Count"
                 },
@@ -621,7 +629,11 @@
                 },
                 {
                     "data_path": "action_result.data.*.domain_risk.risk_score",
-                    "data_type": "numeric",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.domain_risk.risk_score_string",
+                    "data_type": "string",
                     "column_order": 2,
                     "column_name": "Risk Score"
                 },
@@ -775,7 +787,11 @@
                 },
                 {
                     "data_path": "action_result.data.*.domain_risk.risk_score",
-                    "data_type": "numeric",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.domain_risk.risk_score_string",
+                    "data_type": "string",
                     "column_order": 1,
                     "column_name": "Risk Score"
                 },
@@ -938,7 +954,11 @@
                 },
                 {
                     "data_path": "action_result.data.*.domain_risk.risk_score",
-                    "data_type": "numeric",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.domain_risk.risk_score_string",
+                    "data_type": "string",
                     "column_order": 2,
                     "column_name": "Risk Score"
                 },

--- a/domaintools_iris_connector.py
+++ b/domaintools_iris_connector.py
@@ -258,7 +258,13 @@ class DomainToolsConnector(BaseConnector):
         # the default table view from Splunk SOAR template.
         final_result = []
         for result in results_data:
-            result.get("domain_risk").update({"risk_score_string": self._convert_null_value_to_empty_string(result.get("domain_risk", {}).get("risk_score"))})
+            result.get("domain_risk").update(
+                {
+                    "risk_score_string": self._convert_null_value_to_empty_string(
+                        result.get("domain_risk", {}).get("risk_score")
+                    )
+                }
+            )
             final_result.append(result)
 
         # Make the final result sorted in descending order by default
@@ -417,8 +423,7 @@ class DomainToolsConnector(BaseConnector):
 
         return action_result.get_status()
 
-    @staticmethod
-    def _convert_null_value_to_empty_string(value):
+    def _convert_null_value_to_empty_string(self, value):
         return "" if value is None else str(value)
 
     def _domain_enrich(self, param):

--- a/domaintools_iris_connector.py
+++ b/domaintools_iris_connector.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 import phantom.app as phantom
 import requests
 import tldextract
+
 from domaintools import API
 from phantom.action_result import ActionResult
 from phantom.base_connector import BaseConnector
@@ -240,7 +241,12 @@ class DomainToolsConnector(BaseConnector):
             )
 
         self.save_progress(f"Parsing {len(results_data)} results...")
-        response_json["response"]["results"] = results_data
+        response_json["response"]["results"] = self._convert_risk_scores_to_string(results_data)
+        # response_json["response"]["results"] = sorted(
+        #     results_data,
+        #     key=lambda d: 0 if d.get("domain_risk", {}).get("risk_score") is None else d.get("domain_risk", {}).get("risk_score"),
+        #     reverse=True
+        # )
 
         try:
             return self._parse_response(action_result, response_json)
@@ -250,6 +256,21 @@ class DomainToolsConnector(BaseConnector):
                 "An error occurred while parsing DomainTools response",
                 e,
             )
+
+    def _convert_risk_scores_to_string(self, results_data):
+        # We need this to make the table view sortable.
+        # For some unknown reason, numeric values are not sortable using
+        # the default table view from Splunk SOAR template.
+        final_result = []
+        for result in results_data:
+            result.get("domain_risk").update({"risk_score": self._convert_null_value_to_empty_string(result.get("domain_risk", {}).get("risk_score"))})
+            final_result.append(result)
+
+        return sorted(
+            final_result,
+            key=lambda d: 0 if d.get("domain_risk", {}).get("risk_score") == "" else int(d.get("domain_risk", {}).get("risk_score")),
+            reverse=True
+        )
 
     def _test_connectivity(self):
         params = {"domain": "domaintools.net"}
@@ -377,23 +398,31 @@ class DomainToolsConnector(BaseConnector):
                     {
                         "ip": a["address"]["value"],
                         "type": "Host IP",
-                        "count": a["address"]["count"],
+                        "count": self._convert_null_value_to_empty_string(a["address"]["count"]),
                     }
                 )
 
         for a in data[0]["mx"]:
             if "ip" in a:
                 for b in a["ip"]:
-                    ips.append({"ip": b["value"], "type": "MX IP", "count": b["count"]})
+                    ips.append({"ip": b["value"], "type": "MX IP", "count": self._convert_null_value_to_empty_string(b["count"])})
 
         for a in data[0]["name_server"]:
             if "ip" in a:
                 for b in a["ip"]:
-                    ips.append({"ip": b["value"], "type": "NS IP", "count": b["count"]})
+                    ips.append({"ip": b["value"], "type": "NS IP", "count": self._convert_null_value_to_empty_string(b["count"])})
 
-        action_result.update_summary({"ip_list": ips})
+        sorted_ips = sorted(
+            ips,
+            key=lambda d: 0 if d.get("count") == "" else int(d.get("count")),
+            reverse=True)
+        action_result.update_summary({"ip_list": sorted_ips})
 
         return action_result.get_status()
+
+    @staticmethod
+    def _convert_null_value_to_empty_string(value):
+        return "" if value is None else str(value)
 
     def _domain_enrich(self, param):
         self.save_progress("Starting domain_enrich action.")

--- a/iris_domain_profile_view.py
+++ b/iris_domain_profile_view.py
@@ -4,12 +4,13 @@ from utils import unique_list
 def display_domain_profile(provides, all_app_runs, context):
 
     context['results'] = results = []
-    for summary, action_results in all_app_runs:
+    for _, action_results in all_app_runs:
         for result in action_results:
 
             ctx_result = get_ctx_result(result)
-            if (not ctx_result):
+            if not ctx_result:
                 continue
+
             results.append(ctx_result)
 
     return 'iris_domain_profile.html'
@@ -20,14 +21,12 @@ def get_ctx_result(result):
     param = result.get_param()
     data = result.get_data()
 
-    ctx_result['param'] = param
-
     if (data):
+        ctx_result['param'] = param
         ctx_result['data'] = extract_data(data[0])
         sorted_keys = sorted(ctx_result['data'], key=lambda kv_pair: (not kv_pair.startswith('domain'), kv_pair))
         ctx_result['sorted_data'] = []
         for key in sorted_keys:
-          is_list = False
           if ctx_result['data'][key] or ctx_result['data'][key] == 0:
             data_count = ""
             if type(ctx_result['data'][key]) is dict:
@@ -37,11 +36,10 @@ def get_ctx_result(result):
                     continue
                 data_value = value
                 data_count = count if count and count != 0 else ""
-            elif type(ctx_result['data'][key]) is list:
-                is_list = True
-                data_value = ctx_result['data'][key]
             else:
                 data_value = ctx_result['data'][key]
+
+            is_list = isinstance(ctx_result['data'][key], list)
 
             key = " ".join(unique_list(key.split()))
             ctx_result["sorted_data"].append((key, data_value, data_count, is_list))


### PR DESCRIPTION
Demo:
https://www.loom.com/share/58f2091bd52d47e8af3860f74bbe645e

Changes:
1. Fixed issues in sorting risk_score as well as the count in table template.
2. Made the risk_score to be sorted in descending by default.

Screenshots:
![image](https://github.com/DomainTools/domaintoolsiris/assets/126273665/47205db2-8d03-4d3c-9df1-077ffc9b3c9f)
![image](https://github.com/DomainTools/domaintoolsiris/assets/126273665/fc2a5780-5540-4c0e-8de6-4f544286e9e9)
