### PR TITLE
Add missing output data attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 [comment]: # "Auto-generated SOAR connector documentation"
 # DomainTools Iris Investigate
 
-Publisher: DomainTools  
-Connector Version: 1\.4\.0  
-Product Vendor: DomainTools  
-Product Name: DomainTools Iris Investigate  
-Product Version Supported (regex): "\.\*"  
-Minimum Product Version: 5\.2\.0  
+Publisher: DomainTools
+Connector Version: 1\.4\.0
+Product Vendor: DomainTools
+Product Name: DomainTools Iris Investigate
+Product Version Supported (regex): "\.\*"
+Minimum Product Version: 5\.2\.0
 
 This app supports investigative actions to profile domain names, get risk scores, and find connected domains that share the same Whois details, web hosting profiles, SSL certificates, and more on DomainTools Iris Investigate
 
@@ -37,487 +37,487 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **key** |  required  | password | API Key
 **ssl** |  optional  | boolean | Use SSL
 
-### Supported Actions  
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity  
-[domain reputation](#action-domain-reputation) - Evaluates the risk of a given domain  
-[pivot action](#action-pivot-action) - Find domains connected by any supported Iris Investigate search parameter  
-[reverse domain](#action-reverse-domain) - Extract IPs from a single domain response for further pivoting  
-[reverse ip](#action-reverse-ip) - Find domains with web hosting IP, NS IP or MX IP  
-[load search hash](#action-load-search-hash) - Load or monitor Iris Investigate search results by Iris Investigate export hash  
-[reverse email](#action-reverse-email) - Find domains with email in Whois, DNS SOA or SSL certificate  
-[lookup domain](#action-lookup-domain) - Get all Iris Investigate data for a domain using the Iris Investigate API endpoint \(required\)  
-[enrich domain](#action-enrich-domain) - Get all Iris Investigate data for a domain except counts using the high volume Iris Enrich API endpoint \(if provisioned\)  
+### Supported Actions
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity
+[domain reputation](#action-domain-reputation) - Evaluates the risk of a given domain
+[pivot action](#action-pivot-action) - Find domains connected by any supported Iris Investigate search parameter
+[reverse domain](#action-reverse-domain) - Extract IPs from a single domain response for further pivoting
+[reverse ip](#action-reverse-ip) - Find domains with web hosting IP, NS IP or MX IP
+[load search hash](#action-load-search-hash) - Load or monitor Iris Investigate search results by Iris Investigate export hash
+[reverse email](#action-reverse-email) - Find domains with email in Whois, DNS SOA or SSL certificate
+[lookup domain](#action-lookup-domain) - Get all Iris Investigate data for a domain using the Iris Investigate API endpoint \(required\)
+[enrich domain](#action-enrich-domain) - Get all Iris Investigate data for a domain except counts using the high volume Iris Enrich API endpoint \(if provisioned\)
 
 ## action: 'test connectivity'
 Validate the asset configuration for connectivity
 
-Type: **test**  
+Type: **test**
 Read only: **True**
 
 #### Action Parameters
 No parameters are required for this action
 
 #### Action Output
-No Output  
+No Output
 
 ## action: 'domain reputation'
 Evaluates the risk of a given domain
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**domain** |  required  | Domain to query | string |  `url`  `domain` 
+**domain** |  required  | Domain to query | string |  `url`  `domain`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.domain | string |  `url`  `domain` 
-action\_result\.data | string | 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary\.domain\_risk | numeric | 
-action\_result\.summary\.zerolisted | boolean | 
-action\_result\.summary\.proximity | numeric | 
-action\_result\.summary\.threat\_profile | numeric | 
-action\_result\.summary\.threat\_profile\_malware | numeric | 
-action\_result\.summary\.threat\_profile\_phishing | numeric | 
-action\_result\.summary\.threat\_profile\_spam | numeric | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.domain | string |  `url`  `domain`
+action\_result\.data | string |
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary\.domain\_risk | numeric |
+action\_result\.summary\.zerolisted | boolean |
+action\_result\.summary\.proximity | numeric |
+action\_result\.summary\.threat\_profile | numeric |
+action\_result\.summary\.threat\_profile\_malware | numeric |
+action\_result\.summary\.threat\_profile\_phishing | numeric |
+action\_result\.summary\.threat\_profile\_spam | numeric |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'pivot action'
 Find domains connected by any supported Iris Investigate search parameter
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**query\_value** |  required  | Value to query | string |  `url`  `domain`  `ip`  `email` 
-**pivot\_type** |  required  | Field to pivot on | string | 
-**status** |  optional  | Return domains of this registration type | string | 
-**data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
-**tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string | 
-**create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
-**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string | 
-**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string | 
-**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string | 
-**expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
+**query\_value** |  required  | Value to query | string |  `url`  `domain`  `ip`  `email`
+**pivot\_type** |  required  | Field to pivot on | string |
+**status** |  optional  | Return domains of this registration type | string |
+**data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string |
+**tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string |
+**create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string |
+**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string |
+**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string |
+**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string |
+**expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string |
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.create\_date | string | 
-action\_result\.parameter\.create\_date\_within | string | 
-action\_result\.parameter\.data\_updated\_after | string | 
-action\_result\.parameter\.expiration\_date | string | 
-action\_result\.parameter\.first\_seen\_since | string | 
-action\_result\.parameter\.first\_seen\_within | string | 
-action\_result\.parameter\.pivot\_type | string | 
-action\_result\.parameter\.query\_value | string |  `url`  `domain`  `ip`  `email` 
-action\_result\.parameter\.status | string | 
-action\_result\.parameter\.tld | string | 
-action\_result\.data\.\*\.domain | string |  `domain` 
-action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric | 
-action\_result\.data\.\*\.first\_seen\.count | numeric 
-action\_result\.data\.\*\.first\_seen\.value | string 
-action\_result\.data\.\*\.server\_type\.count | numeric 
-action\_result\.data\.\*\.server\_type\.value | string 
-action\_result\.data\.\*\.website\_title\.count | numeric 
-action\_result\.data\.\*\.website\_title\.value | string 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.create\_date | string |
+action\_result\.parameter\.create\_date\_within | string |
+action\_result\.parameter\.data\_updated\_after | string |
+action\_result\.parameter\.expiration\_date | string |
+action\_result\.parameter\.first\_seen\_since | string |
+action\_result\.parameter\.first\_seen\_within | string |
+action\_result\.parameter\.pivot\_type | string |
+action\_result\.parameter\.query\_value | string |  `url`  `domain`  `ip`  `email`
+action\_result\.parameter\.status | string |
+action\_result\.parameter\.tld | string |
+action\_result\.data\.\*\.domain | string |  `domain`
+action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric |
+action\_result\.data\.\*\.first\_seen\.count | numeric
+action\_result\.data\.\*\.first\_seen\.value | string
+action\_result\.data\.\*\.server\_type\.count | numeric
+action\_result\.data\.\*\.server\_type\.value | string
+action\_result\.data\.\*\.website\_title\.count | numeric
+action\_result\.data\.\*\.website\_title\.value | string
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'reverse domain'
 Extract IPs from a single domain response for further pivoting
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**domain** |  required  | Domain to query | string |  `url`  `domain` 
+**domain** |  required  | Domain to query | string |  `url`  `domain`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.domain | string |  `url`  `domain` 
-action\_result\.data | string | 
-action\_result\.data\.\*\.first\_seen\.count | numeric 
-action\_result\.data\.\*\.first\_seen\.value | string 
-action\_result\.data\.\*\.server\_type\.count | numeric 
-action\_result\.data\.\*\.server\_type\.value | string 
-action\_result\.data\.\*\.website\_title\.count | numeric 
-action\_result\.data\.\*\.website\_title\.value | string 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary\.ip\_list\.\*\.count | numeric | 
-action\_result\.summary\.ip\_list\.\*\.ip | string |  `ip` 
-action\_result\.summary\.ip\_list\.\*\.type | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.domain | string |  `url`  `domain`
+action\_result\.data | string |
+action\_result\.data\.\*\.first\_seen\.count | numeric
+action\_result\.data\.\*\.first\_seen\.value | string
+action\_result\.data\.\*\.server\_type\.count | numeric
+action\_result\.data\.\*\.server\_type\.value | string
+action\_result\.data\.\*\.website\_title\.count | numeric
+action\_result\.data\.\*\.website\_title\.value | string
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary\.ip\_list\.\*\.count | numeric |
+action\_result\.summary\.ip\_list\.\*\.ip | string |  `ip`
+action\_result\.summary\.ip\_list\.\*\.type | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'reverse ip'
 Find domains with web hosting IP, NS IP or MX IP
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**ip** |  required  | IP address to query | string |  `ip` 
-**status** |  optional  | Return domains of this registration type | string | 
-**data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
-**tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string | 
-**create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
-**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string | 
-**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string | 
-**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string | 
-**expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
+**ip** |  required  | IP address to query | string |  `ip`
+**status** |  optional  | Return domains of this registration type | string |
+**data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string |
+**tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string |
+**create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string |
+**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string |
+**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string |
+**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string |
+**expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string |
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.create\_date | string | 
-action\_result\.parameter\.create\_date\_within | string | 
-action\_result\.parameter\.data\_updated\_after | string | 
-action\_result\.parameter\.expiration\_date | string | 
-action\_result\.parameter\.first\_seen\_since | string | 
-action\_result\.parameter\.first\_seen\_within | string | 
-action\_result\.parameter\.ip | string |  `ip` 
-action\_result\.parameter\.status | string | 
-action\_result\.parameter\.tld | string | 
-action\_result\.data\.\*\.domain | string |  `domain` 
-action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric | 
-action\_result\.data\.\*\.first\_seen\.count | numeric 
-action\_result\.data\.\*\.first\_seen\.value | string 
-action\_result\.data\.\*\.server\_type\.count | numeric 
-action\_result\.data\.\*\.server\_type\.value | string 
-action\_result\.data\.\*\.website\_title\.count | numeric 
-action\_result\.data\.\*\.website\_title\.value | string 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.create\_date | string |
+action\_result\.parameter\.create\_date\_within | string |
+action\_result\.parameter\.data\_updated\_after | string |
+action\_result\.parameter\.expiration\_date | string |
+action\_result\.parameter\.first\_seen\_since | string |
+action\_result\.parameter\.first\_seen\_within | string |
+action\_result\.parameter\.ip | string |  `ip`
+action\_result\.parameter\.status | string |
+action\_result\.parameter\.tld | string |
+action\_result\.data\.\*\.domain | string |  `domain`
+action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric |
+action\_result\.data\.\*\.first\_seen\.count | numeric
+action\_result\.data\.\*\.first\_seen\.value | string
+action\_result\.data\.\*\.server\_type\.count | numeric
+action\_result\.data\.\*\.server\_type\.value | string
+action\_result\.data\.\*\.website\_title\.count | numeric
+action\_result\.data\.\*\.website\_title\.value | string
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'load search hash'
 Load or monitor Iris Investigate search results by Iris Investigate export hash
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**search\_hash** |  required  | Iris Investigate search hash to load | string | 
+**search\_hash** |  required  | Iris Investigate search hash to load | string |
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.search\_hash | string | 
-action\_result\.data\.\*\.domain | string |  `domain` 
-action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric | 
-action\_result\.data\.\*\.first\_seen\.count | numeric 
-action\_result\.data\.\*\.first\_seen\.value | string 
-action\_result\.data\.\*\.server\_type\.count | numeric 
-action\_result\.data\.\*\.server\_type\.value | string 
-action\_result\.data\.\*\.website\_title\.count | numeric 
-action\_result\.data\.\*\.website\_title\.value | string 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.search\_hash | string |
+action\_result\.data\.\*\.domain | string |  `domain`
+action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric |
+action\_result\.data\.\*\.first\_seen\.count | numeric
+action\_result\.data\.\*\.first\_seen\.value | string
+action\_result\.data\.\*\.server\_type\.count | numeric
+action\_result\.data\.\*\.server\_type\.value | string
+action\_result\.data\.\*\.website\_title\.count | numeric
+action\_result\.data\.\*\.website\_title\.value | string
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'reverse email'
 Find domains with email in Whois, DNS SOA or SSL certificate
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**email** |  required  | Email query | string |  `email` 
-**status** |  optional  | Return domains of this registration type | string | 
-**data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
-**tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string | 
-**create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
-**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string | 
-**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string | 
-**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string | 
-**expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string | 
+**email** |  required  | Email query | string |  `email`
+**status** |  optional  | Return domains of this registration type | string |
+**data\_updated\_after** |  optional  | Iris Investigate records that were updated on or after midnight on this date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string |
+**tld** |  optional  | Limit results to only include domains in a specific top\-level domain \(i\.e\. “tld=com” or “tld=ru”\) | string |
+**create\_date** |  optional  | Only include domains created on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string |
+**create\_date\_within** |  optional  | Only include domains with a whois create date within the specified number of days \(e\.g\. specifying '1' would indicate within the past day\) | string |
+**first\_seen\_within** |  optional  | Only include domains with a current lifecycle first observed within the specified number of seconds \(e\.g\. specifying '86400' would indicate within the past day\) | string |
+**first\_seen\_since** |  optional  | Only include domains with a current lifecycle first observed since a specified datetime. \(Example: 2023\-04\-10T00:00:00+00:00\) | string |
+**expiration\_date** |  optional  | Only include domains expiring on a specific date, in YYYY\-MM\-DD format or relative options \( 'today', 'yesterday' \) | string |
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.create\_date | string | 
-action\_result\.parameter\.create\_date\_within | string | 
-action\_result\.parameter\.data\_updated\_after | string | 
-action\_result\.parameter\.email | string |  `email` 
-action\_result\.parameter\.expiration\_date | string | 
-action\_result\.parameter\.first\_seen\_since | string | 
-action\_result\.parameter\.first\_seen\_within | string | 
-action\_result\.parameter\.status | string | 
-action\_result\.parameter\.tld | string | 
-action\_result\.data\.\*\.domain | string |  `domain` 
-action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric | 
-action\_result\.data\.\*\.first\_seen\.count | numeric 
-action\_result\.data\.\*\.first\_seen\.value | string 
-action\_result\.data\.\*\.server\_type\.count | numeric 
-action\_result\.data\.\*\.server\_type\.value | string 
-action\_result\.data\.\*\.website\_title\.count | numeric 
-action\_result\.data\.\*\.website\_title\.value | string 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.create\_date | string |
+action\_result\.parameter\.create\_date\_within | string |
+action\_result\.parameter\.data\_updated\_after | string |
+action\_result\.parameter\.email | string |  `email`
+action\_result\.parameter\.expiration\_date | string |
+action\_result\.parameter\.first\_seen\_since | string |
+action\_result\.parameter\.first\_seen\_within | string |
+action\_result\.parameter\.status | string |
+action\_result\.parameter\.tld | string |
+action\_result\.data\.\*\.domain | string |  `domain`
+action\_result\.data\.\*\.domain\_risk\.risk\_score | numeric |
+action\_result\.data\.\*\.first\_seen\.count | numeric
+action\_result\.data\.\*\.first\_seen\.value | string
+action\_result\.data\.\*\.server\_type\.count | numeric
+action\_result\.data\.\*\.server\_type\.value | string
+action\_result\.data\.\*\.website\_title\.count | numeric
+action\_result\.data\.\*\.website\_title\.value | string
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'lookup domain'
 Get all Iris Investigate data for a domain using the Iris Investigate API endpoint \(required\)
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**domain** |  required  | Domain to query using the Iris Investigate API | string |  `url`  `domain` 
+**domain** |  required  | Domain to query using the Iris Investigate API | string |  `url`  `domain`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.status | string | 
-action\_result\.parameter\.domain | string |  `url`  `domain` 
-action\_result\.data\.\*\.additional\_whois\_email\.\*\.count | numeric | 
-action\_result\.data\.\*\.additional\_whois\_email\.\*\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.city\.count | numeric | 
-action\_result\.data\.\*\.admin\_contact\.city\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.country\.count | numeric | 
-action\_result\.data\.\*\.admin\_contact\.country\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.fax\.count | numeric | 
-action\_result\.data\.\*\.admin\_contact\.fax\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.name\.count | numeric | 
-action\_result\.data\.\*\.admin\_contact\.name\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.org\.count | numeric | 
-action\_result\.data\.\*\.admin\_contact\.org\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.phone\.count | numeric | 
-action\_result\.data\.\*\.admin\_contact\.phone\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.postal\.count | numeric | 
-action\_result\.data\.\*\.admin\_contact\.postal\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.state\.count | numeric | 
-action\_result\.data\.\*\.admin\_contact\.state\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.street\.count | numeric | 
-action\_result\.data\.\*\.admin\_contact\.street\.value | string | 
-action\_result\.data\.\*\.adsense\.count | numeric | 
-action\_result\.data\.\*\.adsense\.value | string | 
-action\_result\.data\.\*\.alexa | numeric | 
-action\_result\.data\.\*\.billing\_contact\.city\.count | numeric | 
-action\_result\.data\.\*\.billing\_contact\.city\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.country\.count | numeric | 
-action\_result\.data\.\*\.billing\_contact\.country\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.fax\.count | numeric | 
-action\_result\.data\.\*\.billing\_contact\.fax\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.name\.count | numeric | 
-action\_result\.data\.\*\.billing\_contact\.name\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.org\.count | numeric | 
-action\_result\.data\.\*\.billing\_contact\.org\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.phone\.count | numeric | 
-action\_result\.data\.\*\.billing\_contact\.phone\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.postal\.count | numeric | 
-action\_result\.data\.\*\.billing\_contact\.postal\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.state\.count | numeric | 
-action\_result\.data\.\*\.billing\_contact\.state\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.street\.count | numeric | 
-action\_result\.data\.\*\.billing\_contact\.street\.value | string | 
-action\_result\.data\.\*\.create\_date\.count | numeric | 
-action\_result\.data\.\*\.create\_date\.value | string | 
-action\_result\.data\.\*\.email\_domain\.\*\.count | numeric | 
-action\_result\.data\.\*\.email\_domain\.\*\.value | string | 
-action\_result\.data\.\*\.expiration\_date\.count | numeric | 
-action\_result\.data\.\*\.expiration\_date\.value | string | 
-action\_result\.data\.\*\.first\_seen\.count | numeric 
-action\_result\.data\.\*\.first\_seen\.value | string 
-action\_result\.data\.\*\.google\_analytics\.count | numeric | 
-action\_result\.data\.\*\.google\_analytics\.value | string | 
-action\_result\.data\.\*\.ip\.\*\.address\.count | numeric | 
-action\_result\.data\.\*\.ip\.\*\.address\.value | string | 
-action\_result\.data\.\*\.ip\.\*\.asn\.\*\.count | numeric | 
-action\_result\.data\.\*\.ip\.\*\.asn\.\*\.value | string | 
-action\_result\.data\.\*\.ip\.\*\.country\_code\.count | numeric | 
-action\_result\.data\.\*\.ip\.\*\.country\_code\.value | string | 
-action\_result\.data\.\*\.ip\.\*\.isp\.count | numeric | 
-action\_result\.data\.\*\.ip\.\*\.isp\.value | string | 
-action\_result\.data\.\*\.mx\.\*\.domain\.count | numeric | 
-action\_result\.data\.\*\.mx\.\*\.domain\.value | string | 
-action\_result\.data\.\*\.mx\.\*\.host\.count | numeric | 
-action\_result\.data\.\*\.mx\.\*\.host\.value | string | 
-action\_result\.data\.\*\.mx\.\*\.ip\.\*\.count | numeric | 
-action\_result\.data\.\*\.mx\.\*\.ip\.\*\.value | string | 
-action\_result\.data\.\*\.name\_server\.\*\.domain\.count | numeric | 
-action\_result\.data\.\*\.name\_server\.\*\.domain\.value | string | 
-action\_result\.data\.\*\.name\_server\.\*\.host\.count | numeric | 
-action\_result\.data\.\*\.name\_server\.\*\.host\.value | string | 
-action\_result\.data\.\*\.name\_server\.\*\.ip\.\*\.count | numeric | 
-action\_result\.data\.\*\.name\_server\.\*\.ip\.\*\.value | string | 
-action\_result\.data\.\*\.redirect\.count | numeric | 
-action\_result\.data\.\*\.redirect\.value | string | 
-action\_result\.data\.\*\.redirect\_domain\.count | numeric | 
-action\_result\.data\.\*\.redirect\_domain\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.city\.count | numeric | 
-action\_result\.data\.\*\.registrant\_contact\.city\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.country\.count | numeric | 
-action\_result\.data\.\*\.registrant\_contact\.country\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.email\.\*\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.fax\.count | numeric | 
-action\_result\.data\.\*\.registrant\_contact\.fax\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.name\.count | numeric | 
-action\_result\.data\.\*\.registrant\_contact\.name\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.org\.count | numeric | 
-action\_result\.data\.\*\.registrant\_contact\.org\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.phone\.count | numeric | 
-action\_result\.data\.\*\.registrant\_contact\.phone\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.postal\.count | numeric | 
-action\_result\.data\.\*\.registrant\_contact\.postal\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.state\.count | numeric | 
-action\_result\.data\.\*\.registrant\_contact\.state\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.street\.count | numeric | 
-action\_result\.data\.\*\.registrant\_contact\.street\.value | string | 
-action\_result\.data\.\*\.registrant\_name\.count | numeric | 
-action\_result\.data\.\*\.registrant\_name\.value | string | 
-action\_result\.data\.\*\.registrant\_org\.count | numeric | 
-action\_result\.data\.\*\.registrant\_org\.value | string | 
-action\_result\.data\.\*\.registrar\.count | numeric | 
-action\_result\.data\.\*\.registrar\.value | string | 
-action\_result\.data\.\*\.server\_type\.count | numeric 
-action\_result\.data\.\*\.server\_type\.value | string 
-action\_result\.data\.\*\.soa\_email\.\*\.count | numeric | 
-action\_result\.data\.\*\.soa\_email\.\*\.value | string | 
-action\_result\.data\.\*\.ssl\_info\.\*\.hash\.count | numeric | 
-action\_result\.data\.\*\.ssl\_info\.\*\.hash\.value | string | 
-action\_result\.data\.\*\.ssl\_info\.\*\.organization\.count | numeric | 
-action\_result\.data\.\*\.ssl\_info\.\*\.organization\.value | string | 
-action\_result\.data\.\*\.ssl\_info\.\*\.subject\.count | numeric | 
-action\_result\.data\.\*\.ssl\_info\.\*\.subject\.value | string | 
-action\_result\.data\.\*\.tags\.\*\.label | string | 
-action\_result\.data\.\*\.technical\_contact\.city\.count | numeric | 
-action\_result\.data\.\*\.technical\_contact\.city\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.country\.count | numeric | 
-action\_result\.data\.\*\.technical\_contact\.country\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.fax\.count | numeric | 
-action\_result\.data\.\*\.technical\_contact\.fax\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.name\.count | numeric | 
-action\_result\.data\.\*\.technical\_contact\.name\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.org\.count | numeric | 
-action\_result\.data\.\*\.technical\_contact\.org\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.phone\.count | numeric | 
-action\_result\.data\.\*\.technical\_contact\.phone\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.postal\.count | numeric | 
-action\_result\.data\.\*\.technical\_contact\.postal\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.state\.count | numeric | 
-action\_result\.data\.\*\.technical\_contact\.state\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.street\.count | numeric | 
-action\_result\.data\.\*\.technical\_contact\.street\.value | string | 
-action\_result\.summary | string | 
-action\_result\.message | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.status | string |
+action\_result\.parameter\.domain | string |  `url`  `domain`
+action\_result\.data\.\*\.additional\_whois\_email\.\*\.count | numeric |
+action\_result\.data\.\*\.additional\_whois\_email\.\*\.value | string |
+action\_result\.data\.\*\.admin\_contact\.city\.count | numeric |
+action\_result\.data\.\*\.admin\_contact\.city\.value | string |
+action\_result\.data\.\*\.admin\_contact\.country\.count | numeric |
+action\_result\.data\.\*\.admin\_contact\.country\.value | string |
+action\_result\.data\.\*\.admin\_contact\.fax\.count | numeric |
+action\_result\.data\.\*\.admin\_contact\.fax\.value | string |
+action\_result\.data\.\*\.admin\_contact\.name\.count | numeric |
+action\_result\.data\.\*\.admin\_contact\.name\.value | string |
+action\_result\.data\.\*\.admin\_contact\.org\.count | numeric |
+action\_result\.data\.\*\.admin\_contact\.org\.value | string |
+action\_result\.data\.\*\.admin\_contact\.phone\.count | numeric |
+action\_result\.data\.\*\.admin\_contact\.phone\.value | string |
+action\_result\.data\.\*\.admin\_contact\.postal\.count | numeric |
+action\_result\.data\.\*\.admin\_contact\.postal\.value | string |
+action\_result\.data\.\*\.admin\_contact\.state\.count | numeric |
+action\_result\.data\.\*\.admin\_contact\.state\.value | string |
+action\_result\.data\.\*\.admin\_contact\.street\.count | numeric |
+action\_result\.data\.\*\.admin\_contact\.street\.value | string |
+action\_result\.data\.\*\.adsense\.count | numeric |
+action\_result\.data\.\*\.adsense\.value | string |
+action\_result\.data\.\*\.alexa | numeric |
+action\_result\.data\.\*\.billing\_contact\.city\.count | numeric |
+action\_result\.data\.\*\.billing\_contact\.city\.value | string |
+action\_result\.data\.\*\.billing\_contact\.country\.count | numeric |
+action\_result\.data\.\*\.billing\_contact\.country\.value | string |
+action\_result\.data\.\*\.billing\_contact\.fax\.count | numeric |
+action\_result\.data\.\*\.billing\_contact\.fax\.value | string |
+action\_result\.data\.\*\.billing\_contact\.name\.count | numeric |
+action\_result\.data\.\*\.billing\_contact\.name\.value | string |
+action\_result\.data\.\*\.billing\_contact\.org\.count | numeric |
+action\_result\.data\.\*\.billing\_contact\.org\.value | string |
+action\_result\.data\.\*\.billing\_contact\.phone\.count | numeric |
+action\_result\.data\.\*\.billing\_contact\.phone\.value | string |
+action\_result\.data\.\*\.billing\_contact\.postal\.count | numeric |
+action\_result\.data\.\*\.billing\_contact\.postal\.value | string |
+action\_result\.data\.\*\.billing\_contact\.state\.count | numeric |
+action\_result\.data\.\*\.billing\_contact\.state\.value | string |
+action\_result\.data\.\*\.billing\_contact\.street\.count | numeric |
+action\_result\.data\.\*\.billing\_contact\.street\.value | string |
+action\_result\.data\.\*\.create\_date\.count | numeric |
+action\_result\.data\.\*\.create\_date\.value | string |
+action\_result\.data\.\*\.email\_domain\.\*\.count | numeric |
+action\_result\.data\.\*\.email\_domain\.\*\.value | string |
+action\_result\.data\.\*\.expiration\_date\.count | numeric |
+action\_result\.data\.\*\.expiration\_date\.value | string |
+action\_result\.data\.\*\.first\_seen\.count | numeric
+action\_result\.data\.\*\.first\_seen\.value | string
+action\_result\.data\.\*\.google\_analytics\.count | numeric |
+action\_result\.data\.\*\.google\_analytics\.value | string |
+action\_result\.data\.\*\.ip\.\*\.address\.count | numeric |
+action\_result\.data\.\*\.ip\.\*\.address\.value | string |
+action\_result\.data\.\*\.ip\.\*\.asn\.\*\.count | numeric |
+action\_result\.data\.\*\.ip\.\*\.asn\.\*\.value | string |
+action\_result\.data\.\*\.ip\.\*\.country\_code\.count | numeric |
+action\_result\.data\.\*\.ip\.\*\.country\_code\.value | string |
+action\_result\.data\.\*\.ip\.\*\.isp\.count | numeric |
+action\_result\.data\.\*\.ip\.\*\.isp\.value | string |
+action\_result\.data\.\*\.mx\.\*\.domain\.count | numeric |
+action\_result\.data\.\*\.mx\.\*\.domain\.value | string |
+action\_result\.data\.\*\.mx\.\*\.host\.count | numeric |
+action\_result\.data\.\*\.mx\.\*\.host\.value | string |
+action\_result\.data\.\*\.mx\.\*\.ip\.\*\.count | numeric |
+action\_result\.data\.\*\.mx\.\*\.ip\.\*\.value | string |
+action\_result\.data\.\*\.name\_server\.\*\.domain\.count | numeric |
+action\_result\.data\.\*\.name\_server\.\*\.domain\.value | string |
+action\_result\.data\.\*\.name\_server\.\*\.host\.count | numeric |
+action\_result\.data\.\*\.name\_server\.\*\.host\.value | string |
+action\_result\.data\.\*\.name\_server\.\*\.ip\.\*\.count | numeric |
+action\_result\.data\.\*\.name\_server\.\*\.ip\.\*\.value | string |
+action\_result\.data\.\*\.redirect\.count | numeric |
+action\_result\.data\.\*\.redirect\.value | string |
+action\_result\.data\.\*\.redirect\_domain\.count | numeric |
+action\_result\.data\.\*\.redirect\_domain\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.city\.count | numeric |
+action\_result\.data\.\*\.registrant\_contact\.city\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.country\.count | numeric |
+action\_result\.data\.\*\.registrant\_contact\.country\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.email\.\*\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.fax\.count | numeric |
+action\_result\.data\.\*\.registrant\_contact\.fax\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.name\.count | numeric |
+action\_result\.data\.\*\.registrant\_contact\.name\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.org\.count | numeric |
+action\_result\.data\.\*\.registrant\_contact\.org\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.phone\.count | numeric |
+action\_result\.data\.\*\.registrant\_contact\.phone\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.postal\.count | numeric |
+action\_result\.data\.\*\.registrant\_contact\.postal\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.state\.count | numeric |
+action\_result\.data\.\*\.registrant\_contact\.state\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.street\.count | numeric |
+action\_result\.data\.\*\.registrant\_contact\.street\.value | string |
+action\_result\.data\.\*\.registrant\_name\.count | numeric |
+action\_result\.data\.\*\.registrant\_name\.value | string |
+action\_result\.data\.\*\.registrant\_org\.count | numeric |
+action\_result\.data\.\*\.registrant\_org\.value | string |
+action\_result\.data\.\*\.registrar\.count | numeric |
+action\_result\.data\.\*\.registrar\.value | string |
+action\_result\.data\.\*\.server\_type\.count | numeric
+action\_result\.data\.\*\.server\_type\.value | string
+action\_result\.data\.\*\.soa\_email\.\*\.count | numeric |
+action\_result\.data\.\*\.soa\_email\.\*\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.hash\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.hash\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.organization\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.organization\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.subject\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.subject\.value | string |
+action\_result\.data\.\*\.tags\.\*\.label | string |
+action\_result\.data\.\*\.technical\_contact\.city\.count | numeric |
+action\_result\.data\.\*\.technical\_contact\.city\.value | string |
+action\_result\.data\.\*\.technical\_contact\.country\.count | numeric |
+action\_result\.data\.\*\.technical\_contact\.country\.value | string |
+action\_result\.data\.\*\.technical\_contact\.fax\.count | numeric |
+action\_result\.data\.\*\.technical\_contact\.fax\.value | string |
+action\_result\.data\.\*\.technical\_contact\.name\.count | numeric |
+action\_result\.data\.\*\.technical\_contact\.name\.value | string |
+action\_result\.data\.\*\.technical\_contact\.org\.count | numeric |
+action\_result\.data\.\*\.technical\_contact\.org\.value | string |
+action\_result\.data\.\*\.technical\_contact\.phone\.count | numeric |
+action\_result\.data\.\*\.technical\_contact\.phone\.value | string |
+action\_result\.data\.\*\.technical\_contact\.postal\.count | numeric |
+action\_result\.data\.\*\.technical\_contact\.postal\.value | string |
+action\_result\.data\.\*\.technical\_contact\.state\.count | numeric |
+action\_result\.data\.\*\.technical\_contact\.state\.value | string |
+action\_result\.data\.\*\.technical\_contact\.street\.count | numeric |
+action\_result\.data\.\*\.technical\_contact\.street\.value | string |
+action\_result\.summary | string |
+action\_result\.message | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'enrich domain'
 Get all Iris Investigate data for a domain except counts using the high volume Iris Enrich API endpoint \(if provisioned\)
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**domain** |  required  | Domain to query using the Iris Enrich API \(if provisioned\) | string |  `url`  `domain` 
+**domain** |  required  | Domain to query using the Iris Enrich API \(if provisioned\) | string |  `url`  `domain`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.status | string | 
-action\_result\.parameter\.domain | string |  `url`  `domain` 
-action\_result\.data\.\*\.additional\_whois\_email\.\*\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.city\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.country\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.fax\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.name\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.org\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.phone\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.postal\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.state\.value | string | 
-action\_result\.data\.\*\.admin\_contact\.street\.value | string | 
-action\_result\.data\.\*\.adsense\.value | string | 
-action\_result\.data\.\*\.alexa | numeric | 
-action\_result\.data\.\*\.billing\_contact\.city\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.country\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.fax\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.name\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.org\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.phone\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.postal\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.state\.value | string | 
-action\_result\.data\.\*\.billing\_contact\.street\.value | string | 
-action\_result\.data\.\*\.create\_date\.value | string | 
-action\_result\.data\.\*\.email\_domain\.\*\.value | string | 
-action\_result\.data\.\*\.expiration\_date\.value | string | 
-action\_result\.data\.\*\.first\_seen\.value | string 
-action\_result\.data\.\*\.google\_analytics\.value | string | 
-action\_result\.data\.\*\.ip\.\*\.address\.value | string | 
-action\_result\.data\.\*\.ip\.\*\.asn\.\*\.value | string | 
-action\_result\.data\.\*\.ip\.\*\.country\_code\.value | string | 
-action\_result\.data\.\*\.ip\.\*\.isp\.value | string | 
-action\_result\.data\.\*\.mx\.\*\.domain\.value | string | 
-action\_result\.data\.\*\.mx\.\*\.host\.value | string | 
-action\_result\.data\.\*\.mx\.\*\.ip\.\*\.value | string | 
-action\_result\.data\.\*\.name\_server\.\*\.domain\.value | string | 
-action\_result\.data\.\*\.name\_server\.\*\.host\.value | string | 
-action\_result\.data\.\*\.name\_server\.\*\.ip\.\*\.value | string | 
-action\_result\.data\.\*\.redirect\.value | string | 
-action\_result\.data\.\*\.redirect\_domain\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.city\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.country\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.email\.\*\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.fax\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.name\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.org\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.phone\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.postal\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.state\.value | string | 
-action\_result\.data\.\*\.registrant\_contact\.street\.value | string | 
-action\_result\.data\.\*\.registrant\_name\.value | string | 
-action\_result\.data\.\*\.registrant\_org\.value | string | 
-action\_result\.data\.\*\.registrar\.value | string | 
-action\_result\.data\.\*\.server\_type\.value | string 
-action\_result\.data\.\*\.soa\_email\.\*\.value | string | 
-action\_result\.data\.\*\.ssl\_info\.\*\.hash\.value | string | 
-action\_result\.data\.\*\.ssl\_info\.\*\.organization\.value | string | 
-action\_result\.data\.\*\.ssl\_info\.\*\.subject\.value | string | 
-action\_result\.data\.\*\.tags\.\*\.label | string | 
-action\_result\.data\.\*\.technical\_contact\.city\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.country\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.fax\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.name\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.org\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.phone\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.postal\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.state\.value | string | 
-action\_result\.data\.\*\.technical\_contact\.street\.value | string | 
-action\_result\.data\.\*\.website\_title\.value | string 
-action\_result\.summary | string | 
-action\_result\.message | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric | 
+action\_result\.status | string |
+action\_result\.parameter\.domain | string |  `url`  `domain`
+action\_result\.data\.\*\.additional\_whois\_email\.\*\.value | string |
+action\_result\.data\.\*\.admin\_contact\.city\.value | string |
+action\_result\.data\.\*\.admin\_contact\.country\.value | string |
+action\_result\.data\.\*\.admin\_contact\.fax\.value | string |
+action\_result\.data\.\*\.admin\_contact\.name\.value | string |
+action\_result\.data\.\*\.admin\_contact\.org\.value | string |
+action\_result\.data\.\*\.admin\_contact\.phone\.value | string |
+action\_result\.data\.\*\.admin\_contact\.postal\.value | string |
+action\_result\.data\.\*\.admin\_contact\.state\.value | string |
+action\_result\.data\.\*\.admin\_contact\.street\.value | string |
+action\_result\.data\.\*\.adsense\.value | string |
+action\_result\.data\.\*\.alexa | numeric |
+action\_result\.data\.\*\.billing\_contact\.city\.value | string |
+action\_result\.data\.\*\.billing\_contact\.country\.value | string |
+action\_result\.data\.\*\.billing\_contact\.fax\.value | string |
+action\_result\.data\.\*\.billing\_contact\.name\.value | string |
+action\_result\.data\.\*\.billing\_contact\.org\.value | string |
+action\_result\.data\.\*\.billing\_contact\.phone\.value | string |
+action\_result\.data\.\*\.billing\_contact\.postal\.value | string |
+action\_result\.data\.\*\.billing\_contact\.state\.value | string |
+action\_result\.data\.\*\.billing\_contact\.street\.value | string |
+action\_result\.data\.\*\.create\_date\.value | string |
+action\_result\.data\.\*\.email\_domain\.\*\.value | string |
+action\_result\.data\.\*\.expiration\_date\.value | string |
+action\_result\.data\.\*\.first\_seen\.value | string
+action\_result\.data\.\*\.google\_analytics\.value | string |
+action\_result\.data\.\*\.ip\.\*\.address\.value | string |
+action\_result\.data\.\*\.ip\.\*\.asn\.\*\.value | string |
+action\_result\.data\.\*\.ip\.\*\.country\_code\.value | string |
+action\_result\.data\.\*\.ip\.\*\.isp\.value | string |
+action\_result\.data\.\*\.mx\.\*\.domain\.value | string |
+action\_result\.data\.\*\.mx\.\*\.host\.value | string |
+action\_result\.data\.\*\.mx\.\*\.ip\.\*\.value | string |
+action\_result\.data\.\*\.name\_server\.\*\.domain\.value | string |
+action\_result\.data\.\*\.name\_server\.\*\.host\.value | string |
+action\_result\.data\.\*\.name\_server\.\*\.ip\.\*\.value | string |
+action\_result\.data\.\*\.redirect\.value | string |
+action\_result\.data\.\*\.redirect\_domain\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.city\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.country\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.email\.\*\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.fax\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.name\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.org\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.phone\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.postal\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.state\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.street\.value | string |
+action\_result\.data\.\*\.registrant\_name\.value | string |
+action\_result\.data\.\*\.registrant\_org\.value | string |
+action\_result\.data\.\*\.registrar\.value | string |
+action\_result\.data\.\*\.server\_type\.value | string
+action\_result\.data\.\*\.soa\_email\.\*\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.hash\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.organization\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.subject\.value | string |
+action\_result\.data\.\*\.tags\.\*\.label | string |
+action\_result\.data\.\*\.technical\_contact\.city\.value | string |
+action\_result\.data\.\*\.technical\_contact\.country\.value | string |
+action\_result\.data\.\*\.technical\_contact\.fax\.value | string |
+action\_result\.data\.\*\.technical\_contact\.name\.value | string |
+action\_result\.data\.\*\.technical\_contact\.org\.value | string |
+action\_result\.data\.\*\.technical\_contact\.phone\.value | string |
+action\_result\.data\.\*\.technical\_contact\.postal\.value | string |
+action\_result\.data\.\*\.technical\_contact\.state\.value | string |
+action\_result\.data\.\*\.technical\_contact\.street\.value | string |
+action\_result\.data\.\*\.website\_title\.value | string
+action\_result\.summary | string |
+action\_result\.message | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ action\_result\.data\.\*\.billing\_contact\.street\.count | numeric |
 action\_result\.data\.\*\.billing\_contact\.street\.value | string |
 action\_result\.data\.\*\.create\_date\.count | numeric |
 action\_result\.data\.\*\.create\_date\.value | string |
+action\_result\.data\.\*\.domain\_risk\.risk_score | numeric |
 action\_result\.data\.\*\.email\_domain\.\*\.count | numeric |
 action\_result\.data\.\*\.email\_domain\.\*\.value | string |
 action\_result\.data\.\*\.expiration\_date\.count | numeric |
@@ -380,6 +381,7 @@ action\_result\.data\.\*\.registrant\_contact\.city\.value | string |
 action\_result\.data\.\*\.registrant\_contact\.country\.count | numeric |
 action\_result\.data\.\*\.registrant\_contact\.country\.value | string |
 action\_result\.data\.\*\.registrant\_contact\.email\.\*\.value | string |
+action\_result\.data\.\*\.registrant\_contact\.email\.\*\.count | numeric |
 action\_result\.data\.\*\.registrant\_contact\.fax\.count | numeric |
 action\_result\.data\.\*\.registrant\_contact\.fax\.value | string |
 action\_result\.data\.\*\.registrant\_contact\.name\.count | numeric |
@@ -404,13 +406,29 @@ action\_result\.data\.\*\.server\_type\.count | numeric
 action\_result\.data\.\*\.server\_type\.value | string
 action\_result\.data\.\*\.soa\_email\.\*\.count | numeric |
 action\_result\.data\.\*\.soa\_email\.\*\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.alt_names\.\*\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.alt_names\.\*\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.common_name\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.common_name\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.duration\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.duration\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.email\.\*\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.email\.\*\.value | string |
 action\_result\.data\.\*\.ssl\_info\.\*\.hash\.count | numeric |
 action\_result\.data\.\*\.ssl\_info\.\*\.hash\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.issuer_common_name\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.issuer_common_name\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.not_after\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.not_after\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.not_before\.count | numeric |
+action\_result\.data\.\*\.ssl\_info\.\*\.not_before\.value | string |
 action\_result\.data\.\*\.ssl\_info\.\*\.organization\.count | numeric |
 action\_result\.data\.\*\.ssl\_info\.\*\.organization\.value | string |
 action\_result\.data\.\*\.ssl\_info\.\*\.subject\.count | numeric |
 action\_result\.data\.\*\.ssl\_info\.\*\.subject\.value | string |
 action\_result\.data\.\*\.tags\.\*\.label | string |
+action\_result\.data\.\*\.tags\.\*\.scope | string |
+action\_result\.data\.\*\.tags\.\*\.tagged_at | string |
 action\_result\.data\.\*\.technical\_contact\.city\.count | numeric |
 action\_result\.data\.\*\.technical\_contact\.city\.value | string |
 action\_result\.data\.\*\.technical\_contact\.country\.count | numeric |
@@ -429,6 +447,7 @@ action\_result\.data\.\*\.technical\_contact\.state\.count | numeric |
 action\_result\.data\.\*\.technical\_contact\.state\.value | string |
 action\_result\.data\.\*\.technical\_contact\.street\.count | numeric |
 action\_result\.data\.\*\.technical\_contact\.street\.value | string |
+action\_result\.data\.\*\.tld | string |
 action\_result\.summary | string |
 action\_result\.message | string |
 summary\.total\_objects | numeric |
@@ -472,6 +491,7 @@ action\_result\.data\.\*\.billing\_contact\.postal\.value | string |
 action\_result\.data\.\*\.billing\_contact\.state\.value | string |
 action\_result\.data\.\*\.billing\_contact\.street\.value | string |
 action\_result\.data\.\*\.create\_date\.value | string |
+action\_result\.data\.\*\.domain\_risk\.risk_score | numeric |
 action\_result\.data\.\*\.email\_domain\.\*\.value | string |
 action\_result\.data\.\*\.expiration\_date\.value | string |
 action\_result\.data\.\*\.first\_seen\.value | string
@@ -503,10 +523,19 @@ action\_result\.data\.\*\.registrant\_org\.value | string |
 action\_result\.data\.\*\.registrar\.value | string |
 action\_result\.data\.\*\.server\_type\.value | string
 action\_result\.data\.\*\.soa\_email\.\*\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.alt_names\.\*\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.common_name\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.duration\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.email\.\*\.value | string |
 action\_result\.data\.\*\.ssl\_info\.\*\.hash\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.issuer_common_name\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.not_after\.value | string |
+action\_result\.data\.\*\.ssl\_info\.\*\.not_before\.value | string |
 action\_result\.data\.\*\.ssl\_info\.\*\.organization\.value | string |
 action\_result\.data\.\*\.ssl\_info\.\*\.subject\.value | string |
 action\_result\.data\.\*\.tags\.\*\.label | string |
+action\_result\.data\.\*\.tags\.\*\.scope | string |
+action\_result\.data\.\*\.tags\.\*\.tagged_at | string |
 action\_result\.data\.\*\.technical\_contact\.city\.value | string |
 action\_result\.data\.\*\.technical\_contact\.country\.value | string |
 action\_result\.data\.\*\.technical\_contact\.fax\.value | string |
@@ -516,6 +545,7 @@ action\_result\.data\.\*\.technical\_contact\.phone\.value | string |
 action\_result\.data\.\*\.technical\_contact\.postal\.value | string |
 action\_result\.data\.\*\.technical\_contact\.state\.value | string |
 action\_result\.data\.\*\.technical\_contact\.street\.value | string |
+action\_result\.data\.\*\.tld | string |
 action\_result\.data\.\*\.website\_title\.value | string
 action\_result\.summary | string |
 action\_result\.message | string |

--- a/domaintools_iris.json
+++ b/domaintools_iris.json
@@ -1200,6 +1200,10 @@
                     "data_type": "string"
                 },
                 {
+                    "data_path": "action_result.data.*.domain_risk.risk_score",
+                    "data_type": "numeric"
+                },
+                {
                     "data_path": "action_result.data.*.email_domain.*.count",
                     "data_type": "numeric"
                 },
@@ -1348,6 +1352,10 @@
                     "data_type": "string"
                 },
                 {
+                    "data_path": "action_result.data.*.registrant_contact.email.*.count",
+                    "data_type": "numeric"
+                },
+                {
                     "data_path": "action_result.data.*.registrant_contact.fax.count",
                     "data_type": "numeric"
                 },
@@ -1444,11 +1452,67 @@
                     "data_type": "string"
                 },
                 {
+                    "data_path": "action_result.data.*.ssl_info.*.alt_names.*.count",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.alt_names.*.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.common_name.count",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.common_name.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.duration.count",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.duration.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.email.*.count",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.email.*.value",
+                    "data_type": "string"
+                },
+                {
                     "data_path": "action_result.data.*.ssl_info.*.hash.count",
                     "data_type": "numeric"
                 },
                 {
                     "data_path": "action_result.data.*.ssl_info.*.hash.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.issuer_common_name.count",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.issuer_common_name.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.not_after.count",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.not_after.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.not_before.count",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.not_before.value",
                     "data_type": "string"
                 },
                 {
@@ -1469,6 +1533,14 @@
                 },
                 {
                     "data_path": "action_result.data.*.tags.*.label",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.tags.*.scope",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.tags.*.tagged_at",
                     "data_type": "string"
                 },
                 {
@@ -1541,6 +1613,10 @@
                 },
                 {
                     "data_path": "action_result.data.*.technical_contact.street.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.tld",
                     "data_type": "string"
                 },
                 {
@@ -1716,6 +1792,10 @@
                     "data_type": "string"
                 },
                 {
+                    "data_path": "action_result.data.*.domain_risk.risk_score",
+                    "data_type": "numeric"
+                },
+                {
                     "data_path": "action_result.data.*.email_domain.*.value",
                     "data_type": "string"
                 },
@@ -1840,7 +1920,35 @@
                     "data_type": "string"
                 },
                 {
+                    "data_path": "action_result.data.*.ssl_info.*.alt_names.*.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.common_name.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.duration.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.email.*.value",
+                    "data_type": "string"
+                },
+                {
                     "data_path": "action_result.data.*.ssl_info.*.hash.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.issuer_common_name.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.not_after.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.ssl_info.*.not_before.value",
                     "data_type": "string"
                 },
                 {
@@ -1853,6 +1961,14 @@
                 },
                 {
                     "data_path": "action_result.data.*.tags.*.label",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.tags.*.scope",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.tags.*.tagged_at",
                     "data_type": "string"
                 },
                 {
@@ -1889,6 +2005,10 @@
                 },
                 {
                     "data_path": "action_result.data.*.technical_contact.street.value",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.tld",
                     "data_type": "string"
                 },
                 {


### PR DESCRIPTION
Changes:
1. Added the following output data attributes:

- ssl_info.*.alt_names.*.count
- ssl_info.*.alt_names.*.value
- ssl_info.*.common_name.count
- ssl_info.*.common_name.value
- ssl_info.*.duration.count
- ssl_info.*.duration.value
- ssl_info.*.email.*.count
- ssl_info.*.email.*.
- ssl_info.*.issuer_common_name.count
- ssl_info.*.issuer_common_name.value
- ssl_info.*.not_after.count
- ssl_info.*.not_after.value
- ssl_info.*.not_before.count
- ssl_info.*.not_before.value
- tags.*.scope
- tags.*.tagged_at
- tld
- risk_score
- email.count


Demo:
- Refer to the video link on the ticket comments.